### PR TITLE
Add ipython for cashapp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ipython
 numpy>=1.18.2
 pandas>=0.25.1
 scikit-learn==0.22.2


### PR DESCRIPTION
Cashapp team requires an update on the requirements.txt to include "ipython" library. A temporary solution is to include it in `requirements.txt`, but a better solution later is to isolate the visualization from `__init__.py`. 

Detalis refers to here: https://github.com/SAP/contextual-ai/blob/master/xai/compiler/__init__.py 